### PR TITLE
Add a better example for usage with Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Repository: https://github.com/TrafeX/docker-php-nginx
 
 * Built on the lightweight and secure Alpine Linux distribution
 * Very small Docker image size (+/-35MB)
-* Uses PHP 7.3 for better performance, lower cpu usage & memory footprint
+* Uses PHP 7.3 for better performance, lower CPU usage & memory footprint
 * Optimized for 100 concurrent users
-* Optimized to only use resources when there's traffic (by using PHP-FPM's ondemand PM)
+* Optimized to only use resources when there's traffic (by using PHP-FPM's on-demand PM)
 * The servers Nginx, PHP-FPM and supervisord run under a non-privileged user (nobody) to make it more secure
 * The logs of all the services are redirected to the output of the Docker container (visible with `docker logs -f <container name>`)
 * Follows the KISS principle (Keep It Simple, Stupid) to make it easy to understand and adjust the image to your needs
@@ -62,7 +62,7 @@ _Note; Because `-v` requires an absolute path I've added `pwd` in the example to
 
 ## Adding composer
 
-If you need composer in your project, here's an easy way to add it;
+If you need [Composer](https://getcomposer.org/) in your project, here's an easy way to add it.
 
 ```dockerfile
 FROM trafex/alpine-nginx-php7:latest
@@ -72,4 +72,27 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Run composer install to install the dependencies
 RUN composer install --optimize-autoloader --no-interaction --no-progress
+```
+
+### Building with composer
+
+If you are building an image with source code in it and dependencies managed by composer then the definition can be improved.
+The dependencies should be retrieved by the composer but the composer itself (`/usr/bin/composer`) is not necessary to be included in the image.
+
+```Dockerfile
+FROM composer AS composer
+
+# copying the source directory and install the dependencies with composer
+COPY <your_directory>/ /app
+
+# run composer install to install the dependencies
+RUN composer install \
+  --optimize-autoloader \
+  --no-interaction \
+  --no-progress
+
+# continue stage build with the desired image and copy the source including the
+# dependencies downloaded by composer
+FROM trafex/alpine-nginx-php7
+COPY --chown=nginx --from=composer /app /var/www/html
 ```


### PR DESCRIPTION
The section which describes the usage with Composer might be a bit misleading in some scenarios, therefore I added a clarification and an example -- if you just need to download the dependencies then it can be done directly in the composer image rather than copying `/usr/bin/composer` and then removing it.