### PR TITLE
Move defaults removal to upper layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,14 @@ FROM alpine:3.11
 LABEL Maintainer="Tim de Pater <code@trafex.nl>" \
       Description="Lightweight container with Nginx 1.16 & PHP-FPM 7.3 based on Alpine Linux."
 
-# Install packages
+# Install packages and remove default server definition
 RUN apk --no-cache add php7 php7-fpm php7-opcache php7-mysqli php7-json php7-openssl php7-curl \
     php7-zlib php7-xml php7-phar php7-intl php7-dom php7-xmlreader php7-ctype php7-session \
-    php7-mbstring php7-gd nginx supervisor curl
+    php7-mbstring php7-gd nginx supervisor curl && \
+    rm /etc/nginx/conf.d/default.conf
 
 # Configure nginx
 COPY config/nginx.conf /etc/nginx/nginx.conf
-# Remove default server definition
-RUN rm /etc/nginx/conf.d/default.conf
 
 # Configure PHP-FPM
 COPY config/fpm-pool.conf /etc/php7/php-fpm.d/www.conf


### PR DESCRIPTION
Hi @TrafeX ,

After trying to deploy this nice container into a more restricted environment, I've noticed the port 80 was still being required by `nginx` in order to boot.

By executing `sh` within the container, I then realized that the file `/etc/nginx/conf.d/default.conf` was still there even with the `rm` command.

After a bit of research I've learned that due to the Docker nature of steps which stacks files in layers, you need to remove the file in the same layer you added it otherwise it will be inherited from the upper layer.

As weird as it may seem, joining the commands in the same line is the way to fix that and make sure the file will actually be removed.

I hope that this contribution may help others in the future.

Thanks for such a great project!