### PR TITLE
unix socket instead of tcp sockets between nginx and php-fpm

### DIFF
--- a/config/fpm-pool.conf
+++ b/config/fpm-pool.conf
@@ -13,7 +13,7 @@ error_log = /dev/stderr
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = 127.0.0.1:9000
+listen = /run/php-fpm.sock
 
 ; Enable status page
 pm.status_path = /fpm-status

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -51,11 +51,11 @@ http {
             root /var/lib/nginx/html;
         }
 
-        # Pass the PHP scripts to PHP-FPM listening on 127.0.0.1:9000
+        # Pass the PHP scripts to PHP-FPM listening on php-fpm.sock
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_pass unix:/run/php-fpm.sock;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param SCRIPT_NAME $fastcgi_script_name;
             fastcgi_index index.php;
@@ -79,7 +79,7 @@ http {
             deny all;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include fastcgi_params;
-            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_pass unix:/run/php-fpm.sock;
         }
     }
     


### PR DESCRIPTION
UNIX domain sockets know that they’re executing on the same system, so they can avoid some checks and operations (like routing); which makes them faster and lighter than IP sockets. So if you plan to communicate with processes on the same host, this is a better option than IP sockets.