### PR TITLE
Disable absolute_redirect

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -35,6 +35,7 @@ http {
         server_name _;
 
         sendfile off;
+        absolute_redirect off;
 
         root /var/www/html;
         index index.php index.html;


### PR DESCRIPTION
If this is a docker image, then it is safe to assume that most of the time it will be used in a container behind another nginx proxy.

Let's consider the scenario:
> internet -> nginx https (443) -> docker (local port, let's say 8001) -> this container (8080)

Let's now consider the access:
> https://example.com/pub

Assuming `pub` is a directory, nginx will try to add the slash at the end, and the following redirect will take place:
> https://example.com/pub -> http://example.com:8080/pub/

(Please do try it)

Both the protocol (https -> http) and the port (443 -> 8080) change, leaving the site unaccessible. A solution would be to disable `port_in_redirect` in the nginx configuration. That change produces:
> https://example.com/pub -> http://example.com/pub/ -> https://example.com/pub/

(Please try it)

The site is now accessible, but there's an extra redirect because of the protocol change. `absolute_redirect` leaves both the protocol and the port behind so a single redirect takes place.
> https://example.com/pub -> /pub/ (which the browser interprets as https://example.com/pub/)

Even though the `nginx.conf` file can be changed by just binding another file to it, I think it would be better if the default config took this into account.