### PR TITLE
PHP sys_temp_dir does not match Nginx client_body_temp_path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /var/www/html
 
 # Install packages and remove default server definition
 RUN apk add --no-cache \
+  tzdata \
   curl \
   nginx \
   php8 \
@@ -41,7 +42,7 @@ COPY config/php.ini /etc/php8/conf.d/custom.ini
 COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Make sure files/folders needed by the processes are accessable when they run under the nobody user
-RUN chown -R nobody.nobody /var/www/html /run /var/lib/nginx /var/log/nginx
+RUN chown -R nobody:nobody /var/www/html /run /var/lib/nginx /var/log/nginx
 
 # Switch to use a non-root user from here on
 USER nobody

--- a/config/php.ini
+++ b/config/php.ini
@@ -1,2 +1,5 @@
 [Date]
 date.timezone="UTC"
+
+[PHP]
+sys_temp_dir=/tmp/client_temp


### PR DESCRIPTION
During HTTP File Upload (POST), nginx write the temporary files into **/tmp/client_temp** as a non-privileged user (per the configuration in nginx.conf).

But in PHP, the global variable [$_FILES](https://www.php.net/manual/fr/reserved.variables.files.php) **contains the path /tmp** (in $_FILES['userfile']['tmp_name']).

**/tmp** as returned by [sys_get_temp_dir()](https://www.php.net/manual/fr/function.sys-get-temp-dir.php) is wrong here and [move_uploaded_file()](https://www.php.net/manual/fr/function.move-uploaded-file.php) will fail.

A simple change in [PHP] section sys_temp_dir=/tmp/client_temp will do the trick.

I also added the tzdata package to be able to set the timezone with the TZ environnement variable (for example "Europe/Paris". It's a plus for displaying the correct timestamp in the logs output /dev/stdout



 