### PR TITLE
Update location of PHP.ini files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Nginx configuration:
 
 PHP configuration:
 
-    docker run -v "`pwd`/php-setting.ini:/etc/php8/conf.d/settings.ini" trafex/php-nginx
+    docker run -v "`pwd`/php-setting.ini:/etc/php81/conf.d/settings.ini" trafex/php-nginx
 
 PHP-FPM configuration:
 


### PR DESCRIPTION
As this is now PHP 8.1 the files are in the `php81` directory rather than just the `php8` directory.