### PR TITLE
Hide server info and add security headers

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -85,6 +85,11 @@ http {
         }
     }
     
+    # Hardening
+    proxy_hide_header X-Powered-By;
+    fastcgi_hide_header X-Powered-By;
+    server_tokens off;
+    
     gzip on;
     gzip_proxied any;
     gzip_types text/plain application/xml text/css text/js text/xml application/x-javascript text/javascript application/json application/xml+rss;

--- a/config/php.ini
+++ b/config/php.ini
@@ -1,2 +1,3 @@
 [Date]
 date.timezone="UTC"
+expose_php= Off


### PR DESCRIPTION
NGINX and PHP-FPM versions are currently exposed in HTTP headers which are considered not secure enough as exposed OS info. Also added HTTP response headers for higher security.

References:
https://kubernetes.github.io/ingress-nginx/deploy/hardening-guide/
https://www.upguard.com/blog/how-to-build-a-tough-nginx-server-in-15-steps
https://beaglesecurity.com/blog/article/nginx-server-security.html
https://stackoverflow.com/questions/962230/hide-x-powered-by-nginx