### PR TITLE
Chopped up nginx.conf, extracted the server block to /conf.d/default.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,10 @@ RUN apk add --no-cache \
 # Create symlink so programs depending on `php` still function
 RUN ln -s /usr/bin/php81 /usr/bin/php
 
-# Configure nginx
+# Configure nginx - http
 COPY config/nginx.conf /etc/nginx/nginx.conf
+# Configure nginx - default server
+COPY config/conf.d /etc/nginx/conf.d/
 
 # Configure PHP-FPM
 COPY config/fpm-pool.conf /etc/php81/php-fpm.d/www.conf

--- a/config/conf.d/default.conf
+++ b/config/conf.d/default.conf
@@ -1,0 +1,56 @@
+# Default server definition
+server {
+    listen [::]:8080 default_server;
+    listen 8080 default_server;
+    server_name _;
+
+    sendfile off;
+    tcp_nodelay on;
+    absolute_redirect off;
+
+    root /var/www/html;
+    index index.php index.html;
+
+    location / {
+        # First attempt to serve request as file, then
+        # as directory, then fall back to index.php
+        try_files $uri $uri/ /index.php?q=$uri&$args;
+    }
+
+    # Redirect server error pages to the static page /50x.html
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /var/lib/nginx/html;
+    }
+
+    # Pass the PHP scripts to PHP-FPM listening on php-fpm.sock
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+    }
+
+    location ~* \.(jpg|jpeg|gif|png|css|js|ico|xml)$ {
+        expires 5d;
+    }
+
+    # Deny access to . files, for security
+    location ~ /\. {
+        log_not_found off;
+        deny all;
+    }
+
+    # Allow fpm ping and status from localhost
+    location ~ ^/(fpm-status|fpm-ping)$ {
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+        fastcgi_pass unix:/run/php-fpm.sock;
+    }
+}

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -28,74 +28,17 @@ http {
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
 
-    # Default server definition
-    server {
-        listen [::]:8080 default_server;
-        listen 8080 default_server;
-        server_name _;
-
-        sendfile off;
-        tcp_nodelay on;
-        absolute_redirect off;
-
-        root /var/www/html;
-        index index.php index.html;
-
-        location / {
-            # First attempt to serve request as file, then
-            # as directory, then fall back to index.php
-            try_files $uri $uri/ /index.php?q=$uri&$args;
-        }
-
-        # Redirect server error pages to the static page /50x.html
-        error_page 500 502 503 504 /50x.html;
-        location = /50x.html {
-            root /var/lib/nginx/html;
-        }
-
-        # Pass the PHP scripts to PHP-FPM listening on php-fpm.sock
-        location ~ \.php$ {
-            try_files $uri =404;
-            fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_pass unix:/run/php-fpm.sock;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_param SCRIPT_NAME $fastcgi_script_name;
-            fastcgi_index index.php;
-            include fastcgi_params;
-        }
-
-        location ~* \.(jpg|jpeg|gif|png|css|js|ico|xml)$ {
-            expires 5d;
-        }
-
-        # Deny access to . files, for security
-        location ~ /\. {
-            log_not_found off;
-            deny all;
-        }
-
-        # Allow fpm ping and status from localhost
-        location ~ ^/(fpm-status|fpm-ping)$ {
-            access_log off;
-            allow 127.0.0.1;
-            deny all;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            include fastcgi_params;
-            fastcgi_pass unix:/run/php-fpm.sock;
-        }
-    }
-    
     # Hardening
     proxy_hide_header X-Powered-By;
     fastcgi_hide_header X-Powered-By;
     server_tokens off;
-    
+
     gzip on;
     gzip_proxied any;
     gzip_types text/plain application/xml text/css text/js text/xml application/x-javascript text/javascript application/json application/xml+rss;
     gzip_vary on;
     gzip_disable "msie6";
-    
+
     # Include other server configs
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
As requested in #98

If you just want to redefine a different server-block you can put .conf files in your conf.d directory like:

```
# conf.d/redirect.conf
server {
	listen 80 default_server;
	listen [::]:80 default_server;
	return 301 https://$host$request_uri;
}
```
 and

```
# conf.d/my-https-site.conf
server {
	listen 443 default_server ssl;
	listen [::]:443 default_server ssl;
	...
}
```
You can now run the image as a new container with:
```
docker run -v "`pwd`/conf.d:/etc/nginx/conf.d" -p 80:80  -p 443:443 trafex/php-nginx
```

_NOTE: don't forget to add a server-block for the healthcheck:_
```
# conf.d/healthcheck.conf
server {
	listen 8080;
	listen [::]:8080;
	# Allow fpm ping and status from localhost
	location ~ ^/(fpm-status|fpm-ping)$ {
		access_log off;
		allow 127.0.0.1;
		deny all;
		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
		include fastcgi_params;
		fastcgi_pass unix:/run/php-fpm.sock;
	}
}
```

_EDIT: removed 'default_server' from the healthcheck server-block and fixed a typo_