### PR TITLE
Add SimpleXML module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
   php81-openssl \
   php81-phar \
   php81-session \
+  php81-simplexml \
   php81-xml \
   php81-xmlreader \
   supervisor


### PR DESCRIPTION
### Problem

Error occurred 
```
2023/01/06 21:48:58 [error] 10#10: *39 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function simplexml_load_file() in /var/www/html/public/xml.php:7
```
when trying to use function [`simplexml_load_file()`](https://www.php.net/manual/en/function.simplexml-load-file.php).

### Solution

Add SimpleXML module to image.