### PR TITLE
Create symlink for php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Make sure files/folders needed by the processes are accessable when they run under the nobody user
 RUN chown -R nobody.nobody /var/www/html /run /var/lib/nginx /var/log/nginx
 
+# Create symlink for php
+RUN ln -s /usr/bin/php82 /usr/bin/php
+
 # Switch to use a non-root user from here on
 USER nobody
 


### PR DESCRIPTION
since PHP 8.2 it cannot find php when for example the user wants to run composer command:
```
$ composer update
env: can't execute 'php': No such file or directory
```

So I added a symlink in the build step.