### PR TITLE
added ssmtp to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN apk add --no-cache \
   php82-session \
   php82-xml \
   php82-xmlreader \
-  supervisor
+  supervisor \
+  ssmtp
 
 # Configure nginx - http
 COPY config/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
now sendmail is present and uses a configuration you can mount e.g. /mycontainer/nginx-php/ssmtp/ssmtp.conf:/etc/ssmtp/ssmtp.conf that way sending emails via the website will be possible