### PR TITLE
Add `|| exit 1` to `HEALTHCHECK` to map cURL exit codes and Docker possible values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ EXPOSE 8080
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 
 # Configure a healthcheck to validate that everything is up&running
-HEALTHCHECK --timeout=10s CMD curl --silent --fail http://127.0.0.1:8080/fpm-ping
+HEALTHCHECK --timeout=10s CMD curl --silent --fail http://127.0.0.1:8080/fpm-ping || exit 1


### PR DESCRIPTION
**Description:**
This PR maps any returned cURL exit codes to possible values for the Docker `HEALTHCHECK` instruction.

Docker `HEALTHCHECK` instruction possible values:
> The command's exit status indicates the health status of the container. The possible values are:
>
> 0: success - the container is healthy and ready for use
> 1: unhealthy - the container isn't working correctly
> 2: reserved - don't use this exit code

Source: https://docs.docker.com/engine/reference/builder/#healthcheck

cURL exit codes: https://everything.curl.dev/cmdline/exitcode