### PR TITLE
Make php packages easier to upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ ARG ALPINE_VERSION=3.19
 FROM alpine:${ALPINE_VERSION}
 LABEL Maintainer="Tim de Pater <code@trafex.nl>"
 LABEL Description="Lightweight container with Nginx 1.24 & PHP 8.3 based on Alpine Linux."
+
+# Declare variables
+ENV PHP_VERSION 83
+ENV PHP_INI_DIR /etc/php${PHP_VERSION}
+
 # Setup document root
 WORKDIR /var/www/html
 
@@ -9,24 +14,24 @@ WORKDIR /var/www/html
 RUN apk add --no-cache \
   curl \
   nginx \
-  php83 \
-  php83-ctype \
-  php83-curl \
-  php83-dom \
-  php83-fileinfo \
-  php83-fpm \
-  php83-gd \
-  php83-intl \
-  php83-mbstring \
-  php83-mysqli \
-  php83-opcache \
-  php83-openssl \
-  php83-phar \
-  php83-session \
-  php83-tokenizer \
-  php83-xml \
-  php83-xmlreader \
-  php83-xmlwriter \
+  php${PHP_VERSION} \
+  php${PHP_VERSION}-ctype \
+  php${PHP_VERSION}-curl \
+  php${PHP_VERSION}-dom \
+  php${PHP_VERSION}-fileinfo \
+  php${PHP_VERSION}-fpm \
+  php${PHP_VERSION}-gd \
+  php${PHP_VERSION}-intl \
+  php${PHP_VERSION}-mbstring \
+  php${PHP_VERSION}-mysqli \
+  php${PHP_VERSION}-opcache \
+  php${PHP_VERSION}-openssl \
+  php${PHP_VERSION}-phar \
+  php${PHP_VERSION}-session \
+  php${PHP_VERSION}-tokenizer \
+  php${PHP_VERSION}-xml \
+  php${PHP_VERSION}-xmlreader \
+  php${PHP_VERSION}-xmlwriter \
   supervisor
 
 # Configure nginx - http
@@ -35,7 +40,6 @@ COPY config/nginx.conf /etc/nginx/nginx.conf
 COPY config/conf.d /etc/nginx/conf.d/
 
 # Configure PHP-FPM
-ENV PHP_INI_DIR /etc/php83
 COPY config/fpm-pool.conf ${PHP_INI_DIR}/php-fpm.d/www.conf
 COPY config/php.ini ${PHP_INI_DIR}/conf.d/custom.ini
 
@@ -46,7 +50,7 @@ COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 RUN chown -R nobody.nobody /var/www/html /run /var/lib/nginx /var/log/nginx
 
 # Create symlink for php
-RUN ln -s /usr/bin/php83 /usr/bin/php
+RUN if [ ! -f "/usr/bin/php" ]; then ln -s /usr/bin/php${PHP_VERSION} /usr/bin/php; fi
 
 # Switch to use a non-root user from here on
 USER nobody

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -5,7 +5,7 @@ logfile_maxbytes=0
 pidfile=/run/supervisord.pid
 
 [program:php-fpm]
-command=php-fpm83 -F
+command=php-fpm%(ENV_PHP_VERSION)s -F
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
As the title says... I made php version change process easier. 
It requires to change only one variable value to be switched to new php version.

It also set correct php-fpm version in supervisord configuration file.

Hope this changes will be useful.