### PR TITLE
Fix chown command to use colon for user and group separation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY config/php.ini ${PHP_INI_DIR}/conf.d/custom.ini
 COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Make sure files/folders needed by the processes are accessable when they run under the nobody user
-RUN chown -R nobody.nobody /var/www/html /run /var/lib/nginx /var/log/nginx
+RUN chown -R nobody:nobody /var/www/html /run /var/lib/nginx /var/log/nginx
 
 # Switch to use a non-root user from here on
 USER nobody


### PR DESCRIPTION
I updated the `chown` command from `chown -R nobody.nobody` to `chown -R nobody:nobody` to correctly use a colon (`:`) for separating user and group, according to standard usage.

All documentation and man pages for Linux and `chown` tell that a colon should be used for this purpose.