### PR TITLE
Remove the extra q query param with the request URL

### DIFF
--- a/config/conf.d/default.conf
+++ b/config/conf.d/default.conf
@@ -14,7 +14,7 @@ server {
     location / {
         # First attempt to serve request as file, then
         # as directory, then fall back to index.php
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        try_files $uri $uri/ /index.php$is_args$args;
     }
 
     # Redirect server error pages to the static page /50x.html


### PR DESCRIPTION
The request URL was passed on via the `q` param which isn't needed and can be confusing.
 Closing https://github.com/TrafeX/docker-php-nginx/issues/175