### PR TITLE
build: create an alias for `php`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN apk add --no-cache \
   php84-xmlwriter \
   supervisor
 
+RUN ln -s /usr/bin/php84 /usr/bin/php
+
 # Configure nginx - http
 COPY config/nginx.conf /etc/nginx/nginx.conf
 # Configure nginx - default server


### PR DESCRIPTION
This adds an alias for `php`.

It was already done in #58, but removed in d764e5c7d11f8b966b51432bcb0c053fef07fe67.

Some tools expects to have `php` available, eg. `composer`.