### PR TITLE
Change to forcing adding php alias.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache \
   php84-xmlwriter \
   supervisor
 
-RUN ln -s /usr/bin/php84 /usr/bin/php
+RUN ln -sf /usr/bin/php84 /usr/bin/php
 
 # Configure nginx - http
 COPY config/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
There is already a default php alias for some php version. The code `RUN ln -s /usr/bin/php84 /usr/bin/php` will be failed, so just adding `-f` arg to make it work well.