### PR TITLE
Add PDO package and MySQL PDO driver as default packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apk add --no-cache \
   php84-intl \
   php84-mbstring \
   php84-mysqli \
+  php84-pdo \
+  php84-pdo_mysql \
   php84-opcache \
   php84-openssl \
   php84-phar \


### PR DESCRIPTION
Useful for my usecase, and to be totally honest I'd like to just use the base docker image, but I think this might be useful for others too and it seems pretty lightweight.