### PR TITLE
Upgrade to PHP 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ LABEL org.opencontainers.image.source="https://github.com/TrafeX/docker-php-ngin
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.revision="${VCS_REF}"
 LABEL org.opencontainers.image.vendor="TrafeX"
-LABEL org.opencontainers.image.title="PHP-FPM 8.4 & Nginx on Alpine Linux"
-LABEL org.opencontainers.image.description="Lightweight container with Nginx 1.28 & PHP 8.4 based on Alpine Linux."
+LABEL org.opencontainers.image.title="PHP-FPM 8.5 & Nginx on Alpine Linux"
+LABEL org.opencontainers.image.description="Lightweight container with Nginx 1.28 & PHP 8.5 based on Alpine Linux."
 
 # Setup document root
 WORKDIR /var/www/html
@@ -24,24 +24,23 @@ WORKDIR /var/www/html
 RUN apk add --no-cache \
   curl \
   nginx \
-  php84 \
-  php84-ctype \
-  php84-curl \
-  php84-dom \
-  php84-fileinfo \
-  php84-fpm \
-  php84-gd \
-  php84-intl \
-  php84-mbstring \
-  php84-mysqli \
-  php84-opcache \
-  php84-openssl \
-  php84-phar \
-  php84-session \
-  php84-tokenizer \
-  php84-xml \
-  php84-xmlreader \
-  php84-xmlwriter \
+  php85 \
+  php85-ctype \
+  php85-curl \
+  php85-dom \
+  php85-fileinfo \
+  php85-fpm \
+  php85-gd \
+  php85-intl \
+  php85-mbstring \
+  php85-mysqli \
+  php85-openssl \
+  php85-phar \
+  php85-session \
+  php85-tokenizer \
+  php85-xml \
+  php85-xmlreader \
+  php85-xmlwriter \
   supervisor
 
 # Configure nginx - http
@@ -50,7 +49,7 @@ COPY config/nginx.conf /etc/nginx/nginx.conf
 COPY config/conf.d /etc/nginx/conf.d/
 
 # Configure PHP-FPM
-ENV PHP_INI_DIR=/etc/php84
+ENV PHP_INI_DIR=/etc/php85
 COPY config/fpm-pool.conf ${PHP_INI_DIR}/php-fpm.d/www.conf
 COPY config/php.ini ${PHP_INI_DIR}/conf.d/custom.ini
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Docker PHP-FPM 8.4 & Nginx 1.28 on Alpine Linux
-Example PHP-FPM 8.4 & Nginx 1.28 container image for Docker, built on [Alpine Linux](https://www.alpinelinux.org/).
+# Docker PHP-FPM 8.5 & Nginx 1.28 on Alpine Linux
+Example PHP-FPM 8.5 & Nginx 1.28 container image for Docker, built on [Alpine Linux](https://www.alpinelinux.org/).
 
 Repository: https://github.com/TrafeX/docker-php-nginx
 
@@ -7,7 +7,7 @@ Repository: https://github.com/TrafeX/docker-php-nginx
 * Built on the lightweight and secure Alpine Linux distribution
 * Multi-platform, supporting AMD4, ARMv6, ARMv7, ARM64
 * Very small Docker image size (+/-40MB)
-* Uses PHP 8.4 for the best performance, low CPU usage & memory footprint
+* Uses PHP 8.5 for the best performance, low CPU usage & memory footprint
 * Optimized for 100 concurrent users i.e. limits the concurrent requests serving php files
 * Optimized to only use resources when there's traffic (by using PHP-FPM's `on-demand` process manager)
 * The services Nginx, PHP-FPM and supervisord run under a non-privileged user (nobody) to make it more secure
@@ -16,7 +16,7 @@ Repository: https://github.com/TrafeX/docker-php-nginx
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/trafex/php-nginx.svg)](https://hub.docker.com/r/trafex/php-nginx/)
 ![nginx 1.28](https://img.shields.io/badge/nginx-1.28-brightgreen.svg)
-![php 8.4](https://img.shields.io/badge/php-8.4-brightgreen.svg)
+![php 8.5](https://img.shields.io/badge/php-8.5-brightgreen.svg)
 ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 
 ## [![Trafex Consultancy](https://timdepater.com/logo/mini-logo.png)](https://timdepater.com?mtm_campaign=github)
@@ -57,11 +57,11 @@ Nginx configuration:
 
 PHP configuration:
 
-    docker run -v "`pwd`/php-setting.ini:/etc/php84/conf.d/settings.ini" trafex/php-nginx
+    docker run -v "`pwd`/php-setting.ini:/etc/php85/conf.d/settings.ini" trafex/php-nginx
 
 PHP-FPM configuration:
 
-    docker run -v "`pwd`/php-fpm-settings.conf:/etc/php84/php-fpm.d/server.conf" trafex/php-nginx
+    docker run -v "`pwd`/php-fpm-settings.conf:/etc/php85/php-fpm.d/server.conf" trafex/php-nginx
 
 _Note; Because `-v` requires an absolute path I've added `pwd` in the example to return the absolute path to the current directory_
 

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -5,7 +5,7 @@ logfile_maxbytes=0
 pidfile=/run/supervisord.pid
 
 [program:php-fpm]
-command=php-fpm84 -F
+command=php-fpm85 -F
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/docs/xdebug-support.md
+++ b/docs/xdebug-support.md
@@ -27,7 +27,7 @@ FROM trafex/php-nginx:latest
 USER root
 
 # Install xdebug
-RUN apk add --no-cache php84-pecl-xdebug
+RUN apk add --no-cache php85-pecl-xdebug
 
 # Add configuration
 COPY xdebug.ini ${PHP_INI_DIR}/conf.d/xdebug.ini

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 apk --no-cache add curl
-curl --silent --fail http://app:8080 | grep 'PHP 8.4'
+curl --silent --fail http://app:8080 | grep 'PHP 8.5'


### PR DESCRIPTION
## Summary
- Upgrade the container runtime from PHP 8.4 to PHP 8.5 on Alpine.
- Update PHP package names and PHP-FPM binary/config paths to the PHP 8.5 equivalents.
- Update related documentation/examples to reference PHP 8.5.

## Why
- Keep the image aligned with the current PHP minor release for ongoing compatibility, security fixes, and maintenance.

## Notes
- On PHP 8.5, OPcache is now built-in and no longer optional ([PHP8.5 Changelog](https://www.php.net/ChangeLog-8.php#PHP_8_5:~:text=Make%20OPcache%20non%2Doptional)), so it does not require a separate `php85-opcache` package anymore.