### PR TITLE
Recreate alias for php in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ RUN apk add --no-cache \
   php85-xmlwriter \
   supervisor
 
+# Create alias to php
+RUN ln -s /usr/bin/php85 /usr/bin/php
+
 # Configure nginx - http
 COPY config/nginx.conf /etc/nginx/nginx.conf
 # Configure nginx - default server


### PR DESCRIPTION
## Summary

- Restore the `php` alias to point to `php85`.
- Re-add behavior that was introduced in #196 but was removed in `faed4f8`.

## Why

- Keep the expected `php` command available.
- Some tools, such as Composer, expect a `php` binary to be present.
- Avoid regressing behavior that had already been added before.

## Notes

- This only restores the alias; it does not change the PHP version or runtime behavior.